### PR TITLE
Make `includePrefix = true` the default for integer formatters.

### DIFF
--- a/Sources/Prototype_StringFormatting/IntegerFormatting.swift
+++ b/Sources/Prototype_StringFormatting/IntegerFormatting.swift
@@ -1,6 +1,3 @@
-
-// Steve: includePrefix should be true by default...
-
 public struct SeparatorFormatting: Equatable {
   public var separator: Character?
   public var spacing: Int
@@ -56,7 +53,7 @@ public struct IntegerFormatting: Equatable {
   public init(
     radix: Int = 10,
     explicitPositiveSign: Bool = false,
-    includePrefix: Bool = false,
+    includePrefix: Bool = true,
     uppercase: Bool = false,
     minDigits: Int = 1,
     separator: SeparatorFormatting = .none
@@ -87,7 +84,7 @@ public struct IntegerFormatting: Equatable {
 
   public static func hex(
     explicitPositiveSign: Bool = false,
-    includePrefix: Bool = false,
+    includePrefix: Bool = true,
     uppercase: Bool = false,
     minDigits: Int = 1,
     separator: SeparatorFormatting = .none
@@ -105,7 +102,7 @@ public struct IntegerFormatting: Equatable {
 
   public static func octal(
     explicitPositiveSign: Bool = false,
-    includePrefix: Bool = false,
+    includePrefix: Bool = true,
     uppercase: Bool = false,
     minDigits: Int = 1,  // TODO: document if prefix is zero!
     separator: SeparatorFormatting = .none

--- a/Tests/PrototypeStringFormattingTests/PrototypeStringFormattingTests.swift
+++ b/Tests/PrototypeStringFormattingTests/PrototypeStringFormattingTests.swift
@@ -126,9 +126,9 @@ final class Prototype_StringFormatting: XCTestCase {
   }
 
   func test_zero() {
-    expectEqual("0", "\(0, format: .octal())")
+    expectEqual("0", "\(0, format: .octal(includePrefix: false))")
     expectEqual("", "\(0, format: .octal(minDigits: 0))")
-    expectEqual("0o0", "\(0, format: .octal(includePrefix: true))")
+    expectEqual("0o0", "\(0, format: .octal())")
     expectEqual("", "\(0, format: .octal(includePrefix: true, minDigits: 0))")
 
     // TODO: exhaustive corner cases


### PR DESCRIPTION
This is a departure from fprintf convention, but has the highly desirable property that it makes the default format produce something that Swift can ingest as a literal or string, and removes ambiguity.