### PR TITLE
First pass over basic FloatFormatting

### DIFF
--- a/Sources/Prototype_StringFormatting/FloatFormatting.swift
+++ b/Sources/Prototype_StringFormatting/FloatFormatting.swift
@@ -1,80 +1,177 @@
-
 public struct FloatFormatting: Equatable {
-
-  // Steve: default should be Swift optimal format
-  // Me: readable as a Swift literal (as a tie breaker).
-
-  // let x = 0x1.12_32_44p0
-  // Steve: prefer to normalize so it is 1.whatever
-  //   don't customize this for stdlib
-
-  // Me: don't need to be too concerned with extenswibility, packages
-  // can define their own struct and interpolation overloads
-
-  // NOTE: frpintf will read from C locale. Swift print uses dot.
+  // NOTE: fprintf will read from C locale. Swift print uses dot.
   // We could consider a global var for the c locale's character.
   // OSLog will likely end up just getting C locale behavior, which
   // might be a necessary divergence
-  public var radixCharacter: Character = "."
+  public var radixPoint: Character
+  
+  public var explicitPositiveSign: Bool
 
-  // NOTE: Optional because we may want swift-default variable precision,
-  // whereas printf default precision might be something hard coded, like 6
-  //
-  // NOTE: Don't just do minimal-padd-with-zeroes. Ask Steve
-  //
-  // Steve: Consider: precision is # of significant digits
-  //
-  // significant digits is radix-position-agnostic (exponent-agnostic)
-  // accuracy is post-radix # of digits (non-exponential repr)
-  //
-  // alternatively: Int and Bool for # and relative vs absolute
-  // or, it's an enum (shouldn't want both)
-  //
-  // accuracy can be negative to mean pre-radix?
-  public var precision: Int?
-
-  public var explicitPositiveSign: Bool // space is left to higher level, use col width
-
-  // NOTE: `#` flag, include radix even if there are no digits after the radix character.
-  // only relevant if precision is nil or zero, maybe fold into precision?
-  public var includeRadix: Bool
-
-  // f / F. TODO: separate out `e/E`? "inf / INF"? "infinity vs inf"?
-  //
-  // Me: we are not interested in capital-X
-  //
-  // Tim: infinity needs to be a customizable String
-  //   nan too, signaling too,
-  //
-  // NO nan PAYLOAD
-  //
   public var uppercase: Bool
+  
+  // Note: no includePrefix for FloatFormatting; it doesn't exist for
+  // fprintf (%a always prints a prefix, %efg don't need one), so why
+  // introduce it here.
 
-  // TODO: Look at Google's "double precision" library...
-  // TODO: Consider constant strings for inf/nan/exponent, ...
-
-  // TODO: Pad with leading zeroes. Does a "min digits" make sense here? Counting radix?
-
-  public enum Notation {
-    case decimal // %f
-    case exponential // %e
-    case optimal // Swift default, for logging it's %g
-    case hex // an exponential, base-16 format
+  public enum Notation: Equatable {
+    /// Swift's String(floating-point) formatting.
+    case decimal
+    
+    /// Hexadecimal formatting. Only permitted for BinaryFloatingPoint types.
+    case hex
+    
+    /// fprintf's `%f` formatting.
+    ///
+    /// Prints all digits before the radix point, and `precision` digits following
+    /// the radix point. If `precision` is zero, the radix point is omitted.
+    ///
+    /// Note that very large floating-point values may print quite a lot of digits
+    /// when using this format, even if `precision` is zero--up to hundreds for
+    /// `Double`, and thousands for `Float80`. Note also that this format is
+    /// very likely to print non-zero values as all-zero. If either of these is a concern
+    /// for your use, consider using `.optimal` or `.hybrid` instead.
+    ///
+    /// Systems may impose an upper bound on the number of digits that are
+    /// supported following the radix point.
+    case fixed(precision: Int32 = 6)
+    
+    /// fprintf's `%e` formatting.
+    ///
+    /// Prints the number in the form [-]d.ddd...dde±dd, with `precision` significant
+    /// digits following the radix point. Systems may impose an upper bound on the number
+    /// of digits that are supported.
+    case exponential(precision: Int32 = 6)
+    
+    /// fprintf's `%g` formatting.
+    ///
+    /// Behaves like `.fixed` when the number is scaled close to 1.0, and like
+    /// `.exponential` if it has a very large or small exponent.
+    case hybrid(precision: Int32 = 6)
   }
+  
+  public var notation: Notation
 
-  // TODO: does printing preserve sign of zero? YES
-
-  // Steve: default is round-trippable, shortest, "optimal" form
-
-  // TODO: Brainstorm on whiteboard float literals
-
+  public var separator: SeparatorFormatting
+  
+  public init(
+    radixPoint: Character = ".",
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false,
+    notation: Notation = .decimal,
+    separator: SeparatorFormatting = .none
+  ) {
+    self.radixPoint = radixPoint
+    self.explicitPositiveSign = explicitPositiveSign
+    self.uppercase = uppercase
+    self.notation = notation
+    self.separator = separator
+  }
+  
+  public static var decimal: FloatFormatting { .decimal() }
+  
+  public static func decimal(
+    radixPoint: Character = ".",
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false,
+    separator: SeparatorFormatting = .none
+  ) -> FloatFormatting {
+    return FloatFormatting(
+      radixPoint: radixPoint,
+      explicitPositiveSign: explicitPositiveSign,
+      uppercase: uppercase,
+      notation: .decimal,
+      separator: separator
+    )
+  }
+  
+  public static var hex: FloatFormatting { .hex() }
+  
+  public static func hex(
+    radixPoint: Character = ".",
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false,
+    separator: SeparatorFormatting = .none
+  ) -> FloatFormatting {
+    return FloatFormatting(
+      radixPoint: radixPoint,
+      explicitPositiveSign: explicitPositiveSign,
+      uppercase: uppercase,
+      notation: .hex,
+      separator: separator
+    )
+  }
 }
 
 extension FloatFormatting {
+  // Returns a fprintf-compatible length modifier for a given argument type
+  //
+  // @_compilerEvaluable
+  private static func _formatStringLengthModifier<I: FloatingPoint>(
+    _ type: I.Type
+  ) -> String? {
+    switch type {
+    //   fprintf formatters promote Float to Double
+    case is Float.Type: return ""
+    case is Double.Type: return ""
+    //   fprintf formatters use L for Float80
+    case is Float80.Type: return "L"
+    default: return nil
+    }
+  }
+  
   // @_compilerEvaluable
   public func toFormatString<I: FloatingPoint>(
     _ align: String.Alignment = .none, for type: I.Type
   ) -> String? {
-    fatalError()
+    
+    // No separators supported
+    guard separator == SeparatorFormatting.none else { return nil }
+    
+    // Radix character simply comes from C locale, so require it be
+    // default.
+    guard radixPoint == "." else { return nil }
+    
+    // Make sure this is a type that fprintf supports.
+    guard let lengthMod = FloatFormatting._formatStringLengthModifier(type) else { return nil }
+    
+    var specification = "%"
+    
+    // 1. Flags
+    // IEEE: `+` The result of a signed conversion shall always begin with a sign ( '+' or '-' )
+    if explicitPositiveSign {
+      specification += "+"
+    }
+    
+    // IEEE: `-` The result of the conversion shall be left-justified within the field. The
+    //       conversion is right-justified if this flag is not specified.
+    if align.anchor == CollectionBound.start {
+      specification += "-"
+    }
+    
+    // Padding has to be space
+    guard align.fill == " " else {
+      return nil
+    }
+
+    if align.minimumColumnWidth > 0 {
+      specification += "\(align.minimumColumnWidth)"
+    }
+
+    // 3. Precision and conversion specifier.
+    switch notation {
+    case let .fixed(p):
+      specification += "\(p)" + lengthMod + (uppercase ? "F" : "f")
+    case let .exponential(p):
+      specification += "\(p)" + lengthMod + (uppercase ? "E" : "e")
+    case let .hybrid(p):
+      specification += "\(p)" + lengthMod + (uppercase ? "G" : "g")
+    case .hex:
+      guard type.radix == 2 else { return nil }
+      specification += lengthMod + (uppercase ? "A" : "a")
+    default:
+      return nil
+    }
+    
+    return specification
   }
 }


### PR DESCRIPTION
1. use "fixed" for %f, so we can use "decimal" for the one we want to be default.
2. use "decimal" for Swift's formatting (the default).
3. use "precision" throughout for "%e,f,g" since that's the terminology C uses, and these exist to match C.
4. we don't need includePrefix for FloatingPoint, so drop it.
5. constraints on hex to require radix == 2.
6. rename "radixCharacter" to "radixPoint". Be explicit, remove needless words.
7. add Separator.

Plus implement toFormatString (which still needs test coverage, but the basic shape is right).