### PR TITLE
Resolve Regex builder section TODO

### DIFF
--- a/proposals/nnnn-regex-reverse-matching.md
+++ b/proposals/nnnn-regex-reverse-matching.md
@@ -60,7 +60,7 @@ With this proposal, this restriction is lifted and the following syntactic forms
 ```
 
 ### Regex builders
-This proposal adds support for both positibe and negative lookbehind assertions when using the Regex builder, for example:
+This proposal adds support for both positive and negative lookbehind assertions when using the Regex builder, for example:
 
 ```swift
 // Positive Lookbehind
@@ -92,9 +92,9 @@ extension Regex {
   /// Returns a match if this regex matches the given string in its entirety when matching in reverse.
   public func wholeReverseMatch(in string: Substring) throws -> Regex<Output>.Match?
 
-  /// Returns a match if this string is matched by the given regex at its end.
+  /// Returns a match if this string is matched by the given regex (matching in reverse) at its end.
   public func suffixMatch(in string: String) throws -> Regex<Output>.Match?
-  /// Returns a match if this string is matched by the given regex at its end.
+  /// Returns a match if this string is matched by the given regex (matching in reverse) at its end.
   public func suffixMatch(in string: Substring) throws -> Regex<Output>.Match?
 }
 
@@ -105,7 +105,7 @@ extension BidirectionalCollection where SubSequence == Substring {
   public func firstReverseMatch<Output>(@RegexComponentBuilder of content: () -> some RegexComponent<Output>) -> Regex<Output>.Match?
 
   /// Returns a match if this string is matched by the given regex in its entirety when matching in reverse.
-  public func wholeMatch<R: RegexComponent>(of regex: R) -> Regex<R.RegexOutput>.Match?
+  public func wholeReverseMatch<R: RegexComponent>(of regex: R) -> Regex<R.RegexOutput>.Match?
   /// Returns a match if this string is matched by the given regex in its entirety when matching in reverse.
   public func wholeReverseMatch<Output>(@RegexComponentBuilder of content: () -> some RegexComponent<Output>) -> Regex<Output>.Match?
 
@@ -114,14 +114,14 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// Matches part of the regex, starting at the end.
   public func suffixMatch<Output>(@RegexComponentBuilder of content: () -> some RegexComponent<Output>) -> Regex<Output>.Match?
 
-  /// Returns a new collection of the same type by removing the final elements that match the given regex.
+  /// Returns a new collection of the same type by removing the final elements that match the given regex when matching in reverse.
   public func trimmingSuffix(_ regex: some RegexComponent) -> SubSequence
-  /// Returns a new collection of the same type by removing the final elements that match the given regex.
+  /// Returns a new collection of the same type by removing the final elements that match the given regex when matching in reverse.
   public func trimmingSuffix(@RegexComponentBuilder _ content: () -> some RegexComponent) -> SubSequence
 
-  /// Returns a Boolean value indicating whether the final elements of the sequence are the same as the elements in the specified regex.
+  /// Returns a Boolean value indicating whether the final elements of the sequence are the same as the elements in the specified regex when matching in reverse.
   public func ends(with regex: some RegexComponent) -> Bool
-  /// Returns a Boolean value indicating whether the final elements of the sequence are the same as the elements in the specified regex.
+  /// Returns a Boolean value indicating whether the final elements of the sequence are the same as the elements in the specified regex when matching in reverse.
   public func ends(@RegexComponentBuilder with content: () -> some RegexComponent) -> Bool
 }
 ```

--- a/proposals/nnnn-regex-reverse-matching.md
+++ b/proposals/nnnn-regex-reverse-matching.md
@@ -48,21 +48,35 @@ let regex = /(?<=a)b/
 With this proposal, this restriction is lifted and the following syntactic forms will be accepted:
 
 ```swift
-// Positive lookabehind
+// Positive lookbehind
 /a(?<=b)c/
 /a(*plb:b)c/
 /a(*positive_lookbehind:b)c/
 
-// Negative lookabehind
+// Negative lookbehind
 /a(?<!b)c/
 /a(*nlb:b)c/
 /a(*negative_lookbehind:b)c/
-
 ```
 
 ### Regex builders
+This proposal adds support for both positibe and negative lookbehind assertions when using the Regex builder, for example:
 
-**TODO**: add Regex builders for positive and negative lookbehind
+```swift
+// Positive Lookbehind
+Regex {
+  "a"
+  Lookbehind { "b" }
+  "c"
+}
+
+// Negative lookbehind
+Regex {
+  "a"
+  NegativeLookbehind { "b" }
+  "c"
+}
+```
 
 ### API
 

--- a/proposals/nnnn-regex-reverse-matching.md
+++ b/proposals/nnnn-regex-reverse-matching.md
@@ -80,8 +80,51 @@ Regex {
 
 ### API
 
-**TODO**: Add reverse variants of matching API, e.g. `firstReverseMatch()`.
+```swift
+extension Regex {
+  /// Returns the first match for this regex found in the given string when matching in reverse.
+  public func firstReverseMatch(in string: String) throws -> Regex<Output>.Match?
+  /// Returns the first match for this regex found in the given string when matching in reverse.
+  public func firstReverseMatch(in string: Substring) throws -> Regex<Output>.Match?
 
+  /// Returns a match if this regex matches the given string in its entirety when matching in reverse.
+  public func wholeReverseMatch(in string: String) throws -> Regex<Output>.Match?
+  /// Returns a match if this regex matches the given string in its entirety when matching in reverse.
+  public func wholeReverseMatch(in string: Substring) throws -> Regex<Output>.Match?
+
+  /// Returns a match if this string is matched by the given regex at its end.
+  public func suffixMatch(in string: String) throws -> Regex<Output>.Match?
+  /// Returns a match if this string is matched by the given regex at its end.
+  public func suffixMatch(in string: Substring) throws -> Regex<Output>.Match?
+}
+
+extension BidirectionalCollection where SubSequence == Substring {
+  /// Returns the first match of the specified regex within the collection when matching in reverse.
+  public func firstReverseMatch<Output>(of r: some RegexComponent<Output>) -> Regex<Output>.Match?
+  /// Returns the first match of the specified regex within the collection when matching in reverse.
+  public func firstReverseMatch<Output>(@RegexComponentBuilder of content: () -> some RegexComponent<Output>) -> Regex<Output>.Match?
+
+  /// Returns a match if this string is matched by the given regex in its entirety when matching in reverse.
+  public func wholeMatch<R: RegexComponent>(of regex: R) -> Regex<R.RegexOutput>.Match?
+  /// Returns a match if this string is matched by the given regex in its entirety when matching in reverse.
+  public func wholeReverseMatch<Output>(@RegexComponentBuilder of content: () -> some RegexComponent<Output>) -> Regex<Output>.Match?
+
+  /// Matches part of the regex, starting at the end.
+  public func suffixMatch<R: RegexComponent>(of regex: R) -> Regex<R.RegexOutput>.Match?
+  /// Matches part of the regex, starting at the end.
+  public func suffixMatch<Output>(@RegexComponentBuilder of content: () -> some RegexComponent<Output>) -> Regex<Output>.Match?
+
+  /// Returns a new collection of the same type by removing the final elements that match the given regex.
+  public func trimmingSuffix(_ regex: some RegexComponent) -> SubSequence
+  /// Returns a new collection of the same type by removing the final elements that match the given regex.
+  public func trimmingSuffix(@RegexComponentBuilder _ content: () -> some RegexComponent) -> SubSequence
+
+  /// Returns a Boolean value indicating whether the final elements of the sequence are the same as the elements in the specified regex.
+  public func ends(with regex: some RegexComponent) -> Bool
+  /// Returns a Boolean value indicating whether the final elements of the sequence are the same as the elements in the specified regex.
+  public func ends(@RegexComponentBuilder with content: () -> some RegexComponent) -> Bool
+}
+```
 
 ## Source compatibility
 


### PR DESCRIPTION
I'm currently working on listing out the APIs and came across [`Regex.Program.loweredProgram`](https://github.com/swiftlang/swift-experimental-string-processing/blob/main/Sources/_StringProcessing/Regex/Core.swift#L157). My interpretation of this variable's getter is that before making the regex program during Swift's run-time, this getter attempts to read a value that the Swift compiler emitted.

Assuming this reading is correct: I think this could add some complexity into the guts of the reverse matching apis.

My lookbehind implementation changed the instructions the regex compiler emits based on a flag. This means that my current implementation doesn't support using a pre-compiled forwards matching regex as a parameter to the reverse matching methods. The ideas I came up with boil down to modifying the compiled regex program or completely recompiling it and losing out on the Swift compiler's potentially cached value. Are there any other, better ways?